### PR TITLE
Replace the gist links with es imports for the localization demo.

### DIFF
--- a/localizing-functions/index.html
+++ b/localizing-functions/index.html
@@ -11,8 +11,6 @@
       href="//cdnjs.cloudflare.com/ajax/libs/milligram/1.4.0/milligram.css"
     />
     <link rel="stylesheet" href="./src/styles.css" />
-    <script src="https://gistcdn.githack.com/jansiegel/41d3a0b3b955e017ce7e72e23b4fdc91/raw/2c90b351782ac0c1b576ee5cbab73eef20aea2e1/hf-474ae6a.full.js"></script>
-    <script src="https://gistcdn.githack.com/jansiegel/e63e34290e919be060859e5bd1147c29/raw/22250f47ddaafd13e4c6a4a6fb40369f05ced37d/hf-frFR-lang.js"></script>
     <meta charset="UTF-8" />
   </head>
 

--- a/localizing-functions/package.json
+++ b/localizing-functions/package.json
@@ -8,6 +8,9 @@
     "start": "parcel index.html --open",
     "build": "parcel build index.html"
   },
+  "dependencies": {
+    "hyperformula": "0.1.x"
+  },
   "devDependencies": {
     "@babel/core": "7.2.0",
     "parcel-bundler": "^1.6.1"

--- a/localizing-functions/src/hyperformulaConfig.js
+++ b/localizing-functions/src/hyperformulaConfig.js
@@ -1,9 +1,11 @@
+import HyperFormula from "hyperformula";
+import frFR from "hyperformula/es/i18n/languages/frFR";
 import { tableData } from "./data";
 
 // register language
 HyperFormula.registerLanguage(
-  HyperFormula.languages.frFR.langCode,
-  HyperFormula.languages.frFR
+  frFR.langCode,
+  frFR
 );
 
 // Create an empty HyperFormula instance.


### PR DESCRIPTION
Replace the gist links with imports to the HyperFormula and languages builds with a proper path.